### PR TITLE
[12.0] [FIX] fixed typo

### DIFF
--- a/connector_acp_ftp/readme/USAGE.rst
+++ b/connector_acp_ftp/readme/USAGE.rst
@@ -5,6 +5,6 @@ Suggested setup steps for local tests:
   - Install vsftpd: ``sudo apt install vsftpd``.
     Additional documention available at https://help.ubuntu.com/community/vsftpd
   - Edit ``/etc/vsftpd.conf``, changing the entry ``write_enable=YES``
-  - (Res)start the service: ``sudo service vsftpd stop && sudo service vsftpd stop``
+  - (Res)start the service: ``sudo service vsftpd restart``
   - Test the connection with the ``ftp`` client. User you sysytem user and password.
     The FTP default work directory will be your home directory.


### PR DESCRIPTION
I followed Suggested steps base on usage section, so in this step `sudo service vsftpd stop && sudo service vsftpd stop`  but when I connect that time **connection refused** error, because here **service stop**.

Here typo mistake  `sudo service vsftpd stop && sudo service vsftpd start`.

So, In this PR I added little correction like **sudo service vsftpd restart**.